### PR TITLE
fix(media): resolve uploaded media URLs against backend API host

### DIFF
--- a/lib/mappers.ts
+++ b/lib/mappers.ts
@@ -142,7 +142,7 @@ export function mapExperience(dto: ExperienceDTO): Experience {
         translations: translationsRecord,
         tags,
         link: dto.siteUrl ?? '#',
-        image: dto.imageUrl ?? '',
+        image: dto.imageUrl ? mediaSrc(dto.imageUrl) : '',
     };
 }
 
@@ -155,9 +155,7 @@ export function mapSkillCategory(dto: SkillCategoryDTO): SkillCategory {
     const skills = dto.skills.map(skill => {
         const enTranslation = skill.translations.find(t => t.locale === 'en');
         const frTranslation = skill.translations.find(t => t.locale === 'fr');
-        const logo = skill.image?.startsWith('http')
-            ? skill.image
-            : `/${skill.image}`;
+        const logo = mediaSrc(skill.image);
         return {
             name: enTranslation?.name ?? frTranslation?.name ?? '',
             logo,
@@ -171,7 +169,7 @@ export function mapSkillCategory(dto: SkillCategoryDTO): SkillCategory {
 export function mapContact(dto: ContactDTO, locale: Locale): SocialProps {
     return {
         text: dto.nameByLocale[locale] ?? dto.nameByLocale['en'] ?? '',
-        imageUrl: dto.imageUrl,
+        imageUrl: mediaSrc(dto.imageUrl),
         redirectLink: dto.contactUrl,
         cssSize: dto.cssSize ?? 'auto',
     };

--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,9 @@ const config = {
         remotePatterns: [
             {
                 protocol: isDev ? 'http' : 'https',
-                hostname: isDev ? 'localhost' : 'ninhache.fr',
+                // Uploaded media is served by the backend API host, not the
+                // front-end origin. Must match NEXT_PUBLIC_BACKOFFICE_URL's host.
+                hostname: isDev ? 'localhost' : 'api.ninhache.fr',
                 port: isDev ? '5000' : '',
                 pathname: '/uploads/**',
             },


### PR DESCRIPTION
- next.config: allow api.ninhache.fr host for next/image (was ninhache.fr)
- mappers: route experience/contact imageUrl and skill logo through mediaSrc
  so /uploads paths get prefixed with NEXT_PUBLIC_BACKOFFICE_URL instead of
  resolving against the front origin (404)
