### PR TITLE
feat(skills): admin reordering of categories and skills within a category

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -51,7 +51,9 @@ export default async function Page(props: Props) {
     const experiences = rawExperiences
         .filter(e => e.isVisible)
         .map(e => mapExperience(e));
-    const skillCategories = rawCategories.map(c => mapSkillCategory(c));
+    const skillCategories = [...rawCategories]
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+        .map(c => mapSkillCategory(c));
     const profileTrans = profile?.translations.find(t => t.locale === locale);
     const contacts = rawContacts
         .filter(c => c.isVisible)

--- a/app/admin/(auto)/categories/page.tsx
+++ b/app/admin/(auto)/categories/page.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { Pencil, Plus, RefreshCcw, Trash2 } from 'lucide-react';
+import {
+    ArrowDown,
+    ArrowUp,
+    Pencil,
+    Plus,
+    RefreshCcw,
+    Trash2,
+} from 'lucide-react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import {
@@ -88,6 +95,7 @@ export default function CategoriesPage() {
     const [visibilityPending, setVisibilityPending] = useState<string | null>(
         null
     );
+    const [reordering, setReordering] = useState(false);
 
     const load = async () => {
         setLoading(true);
@@ -96,7 +104,9 @@ export default function CategoriesPage() {
                 CategoryApi.findAll(),
                 SkillApi.findAll(),
             ]);
-            setCategories(cats);
+            setCategories(
+                [...cats].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+            );
             setAllSkills(skills);
         } finally {
             setLoading(false);
@@ -156,6 +166,41 @@ export default function CategoriesPage() {
         }));
     };
 
+    /** Move a selected skill up/down in the dialog's display-order list. */
+    const moveSkill = (index: number, dir: -1 | 1) => {
+        setForm(prev => {
+            const next = [...prev.skillIds];
+            const target = index + dir;
+            if (target < 0 || target >= next.length) return prev;
+            [next[index], next[target]] = [next[target], next[index]];
+            return { ...prev, skillIds: next };
+        });
+    };
+
+    /**
+     * Swap a category with its neighbour and persist the whole ordering in one
+     * batch request. Optimistic: the table reverts if the backend rejects.
+     */
+    const moveCategory = async (index: number, dir: -1 | 1) => {
+        const target = index + dir;
+        if (target < 0 || target >= categories.length) return;
+
+        const previous = categories;
+        const next = [...categories];
+        [next[index], next[target]] = [next[target], next[index]];
+        setCategories(next);
+        setReordering(true);
+        try {
+            await CategoryApi.reorder(
+                next.map((c, i) => ({ id: c.id, order: i }))
+            );
+        } catch {
+            setCategories(previous);
+        } finally {
+            setReordering(false);
+        }
+    };
+
     return (
         <AdminPageShell>
             <AdminHeader
@@ -193,6 +238,9 @@ export default function CategoriesPage() {
                         <Table>
                             <TableHeader className="sticky top-0 z-10 bg-muted/60 backdrop-blur supports-[backdrop-filter]:bg-muted/40">
                                 <TableRow>
+                                    <TableHead className="w-24">
+                                        Ordre
+                                    </TableHead>
                                     <TableHead>Nom (FR)</TableHead>
                                     <TableHead className="hidden md:table-cell">
                                         Nom (EN)
@@ -205,12 +253,52 @@ export default function CategoriesPage() {
                                 </TableRow>
                             </TableHeader>
                             <TableBody>
-                                {categories.map(cat => (
+                                {categories.map((cat, index) => (
                                     <TableRow
                                         key={cat.id}
                                         className="cursor-pointer hover:bg-muted/50"
                                         onDoubleClick={() => openEdit(cat)}
                                     >
+                                        <TableCell
+                                            onDoubleClick={e =>
+                                                e.stopPropagation()
+                                            }
+                                        >
+                                            <div className="inline-flex items-center gap-0.5">
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className="h-7 w-7"
+                                                    aria-label="Monter"
+                                                    disabled={
+                                                        reordering ||
+                                                        index === 0
+                                                    }
+                                                    onClick={() =>
+                                                        moveCategory(index, -1)
+                                                    }
+                                                >
+                                                    <ArrowUp className="h-4 w-4" />
+                                                </Button>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className="h-7 w-7"
+                                                    aria-label="Descendre"
+                                                    disabled={
+                                                        reordering ||
+                                                        index ===
+                                                            categories.length -
+                                                                1
+                                                    }
+                                                    onClick={() =>
+                                                        moveCategory(index, 1)
+                                                    }
+                                                >
+                                                    <ArrowDown className="h-4 w-4" />
+                                                </Button>
+                                            </div>
+                                        </TableCell>
                                         <TableCell className="font-medium">
                                             {getCategoryName(cat, 'fr')}
                                         </TableCell>
@@ -333,7 +421,7 @@ export default function CategoriesPage() {
                                 {!loading && categories.length === 0 && (
                                     <TableRow>
                                         <TableCell
-                                            colSpan={5}
+                                            colSpan={6}
                                             className="h-32 text-center text-muted-foreground"
                                         >
                                             Aucune catégorie.
@@ -343,7 +431,7 @@ export default function CategoriesPage() {
                                 {loading && (
                                     <TableRow>
                                         <TableCell
-                                            colSpan={5}
+                                            colSpan={6}
                                             className="h-32 text-center text-muted-foreground"
                                         >
                                             Chargement…
@@ -415,6 +503,80 @@ export default function CategoriesPage() {
                                 Compétences ({form.skillIds.length}{' '}
                                 sélectionnées)
                             </Label>
+
+                            {form.skillIds.length > 0 && (
+                                <div className="space-y-1">
+                                    <p className="text-xs text-muted-foreground">
+                                        Ordre d&apos;affichage — utilisez les
+                                        flèches pour réordonner.
+                                    </p>
+                                    <div className="rounded-md border p-2 space-y-1">
+                                        {form.skillIds.map((id, index) => {
+                                            const skill = allSkills.find(
+                                                s => s.id === id
+                                            );
+                                            if (!skill) return null;
+                                            return (
+                                                <div
+                                                    key={id}
+                                                    className="flex items-center gap-2 rounded px-2 py-1"
+                                                >
+                                                    <span className="w-5 text-xs text-muted-foreground tabular-nums">
+                                                        {index + 1}
+                                                    </span>
+                                                    {skill.image && (
+                                                        <Image
+                                                            src={assetUrl(
+                                                                skill.image
+                                                            )}
+                                                            alt=""
+                                                            width={20}
+                                                            height={20}
+                                                            className="rounded object-contain"
+                                                            unoptimized
+                                                        />
+                                                    )}
+                                                    <span className="flex-1 text-sm">
+                                                        {getSkillName(skill)}
+                                                    </span>
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="h-7 w-7"
+                                                        aria-label="Monter"
+                                                        disabled={index === 0}
+                                                        onClick={() =>
+                                                            moveSkill(index, -1)
+                                                        }
+                                                    >
+                                                        <ArrowUp className="h-4 w-4" />
+                                                    </Button>
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="h-7 w-7"
+                                                        aria-label="Descendre"
+                                                        disabled={
+                                                            index ===
+                                                            form.skillIds
+                                                                .length -
+                                                                1
+                                                        }
+                                                        onClick={() =>
+                                                            moveSkill(index, 1)
+                                                        }
+                                                    >
+                                                        <ArrowDown className="h-4 w-4" />
+                                                    </Button>
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            )}
+
                             <div className="max-h-64 overflow-y-auto rounded-md border p-2 space-y-1">
                                 {allSkills.map(skill => (
                                     <div

--- a/docs/specs/skill-category-ordering.md
+++ b/docs/specs/skill-category-ordering.md
@@ -1,0 +1,98 @@
+# Spec — Ordering of skill categories and skills within a category
+
+**Status:** Draft — backend contract + frontend implementation
+**Date:** 2026-06-04
+**Repos involved:** `Ninhachedotcomv4-seo` (frontend, this repo) + `Ninhachedotcomv4-back` (backend, separate repo)
+
+## 1. Problem
+
+The admin "Catégories de compétences" page (`app/admin/(auto)/categories/page.tsx`,
+described to users as *"Organise les compétences par catégorie"*) lets an admin set a
+category's name, visibility, and which skills belong to it — but there is **no way to
+control display order**. Both `SkillCategoryDTO` and `SkillDTO` lack any `order`/`position`
+field, and the public site (`lib/mappers.ts` → `app/_components/skills.tsx`) renders
+categories and skills in whatever order the backend returns (DB/insertion order).
+
+Goal: an admin can control (a) the order categories appear on the portfolio and
+(b) the order of skills *within* each category. UX: up/down arrows (no drag-and-drop).
+
+## 2. Scope
+
+- **In scope:** category ordering; skill ordering within a category; persisting both;
+  the public site honoring both orders.
+- **Out of scope:** drag-and-drop; per-locale ordering; ordering on any other resource.
+
+## 3. Data model
+
+- A category has a single global display order → an integer column on the category entity.
+- A skill belongs to **many** categories (`skill.categories[]` / `category.skills[]` are
+  many-to-many). Its order is therefore **per-category** and must live on the **join
+  table**, not on the skill entity. The same skill can sit at position 0 in one category
+  and position 3 in another.
+
+## 4. Backend contract (to implement in `Ninhachedotcomv4-back`)
+
+### 4.1 Category order
+
+- Add `order: int` (default `0`) to the category entity.
+- Include `order` in every category DTO (public GET `/skill/categories`, admin GET
+  `/skill/categories/admin`).
+- Sort returned categories by `order ASC`, tiebreak by `id` (stable).
+
+### 4.2 Skill order within a category — **no new endpoint**
+
+Reuse the existing write contract. `POST /skill/categories` and
+`PATCH /skill/categories/:id` already accept `skillIds: string[]`. **The order of that
+array becomes the skill display order within the category** (persisted on the join row).
+
+- On GET, `category.skills[]` MUST be returned sorted by that stored per-join order.
+- On write, the backend persists join order = array index of each id in `skillIds`.
+
+This keeps skill reordering free of any new endpoint — the admin sends the ordered list.
+
+### 4.3 Category reorder — batch endpoint
+
+```
+PATCH /skill/categories/reorder
+Authorization: Bearer <token>
+Body: { "items": [ { "id": "<catId>", "order": 0 }, { "id": "<catId>", "order": 1 }, ... ] }
+Response: 200 (no body required, or the updated category list)
+```
+
+Batch (one atomic request) rather than N per-item PATCHes — avoids races and keeps the
+up/down swap consistent. The frontend sends the **full** ordered list so the backend can
+assign `order = index` directly.
+
+## 5. Frontend changes (this repo)
+
+1. `lib/types.ts` — add `order: number` to `SkillCategoryDTO`.
+2. `lib/skill/skill.api.ts` — add
+   `CategoryApi.reorder(items: { id: string; order: number }[])` →
+   `PATCH /skill/categories/reorder`.
+3. `app/admin/(auto)/categories/page.tsx`:
+   - Sort the loaded categories by `order` before rendering.
+   - Add an "Ordre" column with ↑/↓ buttons per row; a click swaps adjacent categories,
+     updates local state optimistically, and persists via `CategoryApi.reorder()` (rollback on error).
+   - In the edit dialog, render the **selected** skills as an ordered list with ↑/↓
+     arrows; `handleSave` sends `skillIds` in that order. Keep the existing unselected-skill
+     checklist for adding/removing.
+4. Public read path — sort so the order shows:
+   - `lib/mappers.ts` `mapSkillCategory`: the backend returns skills pre-sorted, so keep
+     mapping in array order (no change needed there).
+   - `app/[locale]/page.tsx`: sort `rawCategories` by `order` before mapping (defensive —
+     backend already sorts, but the public DTO type gains `order` so we honor it).
+
+## 6. Acceptance criteria
+
+- [ ] Admin can move a category up/down; reload shows the persisted order.
+- [ ] Admin can reorder skills inside a category's edit dialog; save persists; reload shows it.
+- [ ] Public portfolio renders categories and skills in the admin-defined order.
+- [ ] No regression: visibility toggle, create/edit/delete still work.
+- [ ] `biome check` + `tsc --noEmit` pass.
+
+## 7. Frontend behavior if backend not yet deployed
+
+The frontend degrades safely: `order` is read with `?? 0`, so missing values sort stably
+by insertion order (current behavior). `CategoryApi.reorder()` will 404 until the backend
+ships — the optimistic UI rolls back on error, so the table simply reverts. Skill ordering
+via `skillIds` order is inert until the backend honors array order.

--- a/lib/skill/skill.api.ts
+++ b/lib/skill/skill.api.ts
@@ -77,4 +77,12 @@ export const CategoryApi = {
 
     remove: (id: string): Promise<void> =>
         unwrap(api.delete(`/skill/categories/${id}`)),
+
+    /**
+     * Persist the display order of categories in a single atomic request.
+     * Send the full ordered list; the backend assigns `order = index`.
+     * @param items category ids paired with their new zero-based order
+     */
+    reorder: (items: { id: string; order: number }[]): Promise<void> =>
+        unwrap(api.patch('/skill/categories/reorder', { items })),
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -120,7 +120,12 @@ export type SkillCategoryTranslationDTO = {
 export type SkillCategoryDTO = {
     id: string;
     isVisible: boolean;
+    // Display order on the public portfolio (ascending). Defaults to 0 when the
+    // backend predates the ordering feature — callers sort with `?? 0`.
+    order: number;
     translations: SkillCategoryTranslationDTO[];
+    // Returned pre-sorted by the per-category join order; array order IS the
+    // skill display order within this category.
     skills: SkillDTO[];
 };
 export type SkillDTO = {


### PR DESCRIPTION
Categories get an `order` field; admin can move them up/down (batch
PATCH /skill/categories/reorder, optimistic with rollback). Skill order
within a category is driven by the existing skillIds array order, now
reorderable via up/down arrows in the edit dialog. Public page sorts
categories by order. Backend contract documented in
docs/specs/skill-category-ordering.md (separate repo must implement it).
